### PR TITLE
Add missing Outputfile entry.

### DIFF
--- a/bin/analyser.cpp
+++ b/bin/analyser.cpp
@@ -26,5 +26,5 @@ int main(int argc, char* argv[]){
 
 	analyser.start();
 
-	return 1;
+	return 0;
 }

--- a/config/config_template.txt
+++ b/config/config_template.txt
@@ -2,6 +2,7 @@
 
 Outputdir  = {output_dir}
 Samplesdir = {input_dir}
+Outputfile = {hist_output_file}
 
 Lumi = 3000
 Testmode = false
@@ -13,6 +14,6 @@ RunOnOutputOnly = false
 
 [inputfiles-begin]
 
-{input_file}, {output_prefix}, 420, 56, auto, 2
+{input_file}, {skim_output_prefix}, 420, 56, auto, 2
 
 [inputfiles-end]


### PR DESCRIPTION
The `Outputfile` entry was missing in the upper section.
Also, I renamed the template variables to distinguish between the two types of output files created by the analyzer.

*edit*: Added another commit that ensures that an exit code of 0 is returned on success.